### PR TITLE
Add linkin aainst stdc++fs for older Linux distros

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,8 @@ deps = [
 ]
 
 if (host_machine.system() == 'linux')
+    add_global_link_arguments([ '-lstdc++fs' ], language: 'cpp')
+
     deps += [
         dependency('tbb'),
         meson.get_compiler('c').find_library('dl')


### PR DESCRIPTION
There are no missing letters in the commit message, right Miko :)