### PR TITLE
Team/minute to midnight/fix/collision detection

### DIFF
--- a/source/dagger/gameplay/atonement/char_controller_fsm.cpp
+++ b/source/dagger/gameplay/atonement/char_controller_fsm.cpp
@@ -83,7 +83,7 @@ void CharControllerFSM::Walking::Run(CharControllerFSM::StateComponent& state_)
 			sprite.scale.x *= -1;
 		}
 
-		if((collision.colidedLeft && sprite.scale.x < 0) || (collision.colidedRight && sprite.scale.x > 0)){
+		if((collision.collidedLeft && sprite.scale.x < 0) || (collision.collidedRight && sprite.scale.x > 0)){
 			transform.position.x -= movedInLastFrame;
 			movedInLastFrame = 0;
 		}
@@ -141,7 +141,7 @@ void CharControllerFSM::JumpWindup::Run(CharControllerFSM::StateComponent& state
 			sprite.scale.x *= -1;
 		}
 
-		if ((collision.colidedLeft && sprite.scale.x < 0) || (collision.colidedRight && sprite.scale.x > 0)) {
+		if ((collision.collidedLeft && sprite.scale.x < 0) || (collision.collidedRight && sprite.scale.x > 0)) {
 			transform.position.x -= movedInLastFrame;
 			movedInLastFrame = 0;
 		}
@@ -151,12 +151,12 @@ void CharControllerFSM::JumpWindup::Run(CharControllerFSM::StateComponent& state
 		}
 	}
 
-	if (character.jumpedHeight < character.jumpHeight && !collision.colidedUp) {
+	if (character.jumpedHeight < character.jumpHeight && !collision.collidedUp) {
 		Float32 tmp = character.jumpSpeed * sprite.scale.y * Engine::DeltaTime();
 		transform.position.y += tmp;
 		character.jumpedHeight += tmp;
 	}
-	else if (collision.colidedUp) {
+	else if (collision.collidedUp) {
 		transform.position.y -= jumpedInLastFrame;
 		jumpedInLastFrame = 0;
 		character.jumpedHeight = 0;
@@ -204,7 +204,7 @@ void CharControllerFSM::JumpWinddown::Run(CharControllerFSM::StateComponent& sta
 			sprite.scale.x *= -1;
 		}
 
-		if ((collision.colidedLeft && sprite.scale.x < 0) || (collision.colidedRight && sprite.scale.x > 0)) {
+		if ((collision.collidedLeft && sprite.scale.x < 0) || (collision.collidedRight && sprite.scale.x > 0)) {
 			transform.position.x -= movedInLastFrame;
 			movedInLastFrame = 0;
 		}
@@ -247,7 +247,7 @@ void CharControllerFSM::Dashing::Run(CharControllerFSM::StateComponent& state_)
 
 	auto&& [transform, sprite, character, collision] = Engine::Registry().get<Transform, Sprite, AtonementController::AtonementCharacter, CharacterCollision>(state_.entity);
 
-	Bool collided = (collision.colidedLeft && sprite.scale.x < 0) || (collision.colidedRight && sprite.scale.x > 0);
+	Bool collided = (collision.collidedLeft && sprite.scale.x < 0) || (collision.collidedRight && sprite.scale.x > 0);
 
 	if (collided) {
 		transform.position.x -= dashedInLastFrame;

--- a/source/dagger/gameplay/atonement/systems/character_collisions.cpp
+++ b/source/dagger/gameplay/atonement/systems/character_collisions.cpp
@@ -4,6 +4,8 @@
 #include "core/engine.h"
 #include "core/game/transforms.h"
 
+#include <iostream>
+
 using namespace dagger;
 using namespace atonement;
 
@@ -34,27 +36,27 @@ void CharacterCollisionsSystem::Run()
 
             auto& otherCollision = simpleView.get<SimpleCollision>(entity);
             auto& otherTransform = simpleView.get<Transform>(entity);
-           
+
             CollisionSide collisionDetection = charCollision.IsCollided(charTransform.position, otherTransform.position, otherCollision);
-            
+
             switch (collisionDetection) {
-                case CollisionSide::Left: 
-                    charCollision.collidedLeft = true;
-                    charCollision.collidedWithLeft = entity;
-                    break;
-                case CollisionSide::Right:
-                    charCollision.collidedRight = true;
-                    charCollision.collidedWithRight = entity;
-                    break;
-                case CollisionSide::Up:
-                    charCollision.collidedUp = true;
-                    charCollision.collidedWithUp = entity;
-                    break;
-                case CollisionSide::Down:
-                    charCollision.collidedDown = true;
-                    charCollision.collidedWithDown = entity;
-                    break;
-                default: break;
+            case CollisionSide::Left:
+                charCollision.collidedLeft = true;
+                charCollision.collidedWithLeft = entity;
+                break;
+            case CollisionSide::Right:
+                charCollision.collidedRight = true;
+                charCollision.collidedWithRight = entity;
+                break;
+            case CollisionSide::Up:
+                charCollision.collidedUp = true;
+                charCollision.collidedWithUp = entity;
+                break;
+            case CollisionSide::Down:
+                charCollision.collidedDown = true;
+                charCollision.collidedWithDown = entity;
+                break;
+            default: break;
             }
         }
 
@@ -66,38 +68,46 @@ CollisionSide CharacterCollision::IsCollided(const Vector3& pos_, const Vector3&
     Vector2 p(pos_.x, pos_.y);
     Vector2 p2(posOther_.x, posOther_.y);
 
-    if (p.x < p2.x && ((p2.x - p.x) < (size.x + colOther_.size.x) / 2.f ) &&
-        std::abs(p.y - p2.y) < (size.y + colOther_.size.y) / 2.f )
-    {   
+    Float32 horizontalOverlap = 0;
+    Float32 verticalOverlap = 0;
+
+    if (std::abs(p2.x - p.x) < (size.x + colOther_.size.x) / 2.f &&
+        std::abs(p.y - p2.y) < (size.y + colOther_.size.y) / 2.f) {
         
-        if (p.y + size.y / 2.f < p2.y) { return CollisionSide::Up; }
-        else if (p.y - size.y / 2.f > p2.y) { return CollisionSide::Down; }
+        if (p.x + size.x / 2.f < p2.x + colOther_.size.x / 2.f) {
+            horizontalOverlap = (p.x + size.x / 2.f) - (p2.x - colOther_.size.x / 2.f);
+        }
+        else {
+            horizontalOverlap = (p2.x + colOther_.size.x / 2.f) - (p.x - size.x / 2.f);
+        }
 
-        return CollisionSide::Right;
+        if (p.y + size.y / 2.f < p2.y + colOther_.size.y / 2.f) {
+            verticalOverlap = (p.y + size.y / 2.f) - (p2.y - colOther_.size.y / 2.f);
+        }
+        else {
+            verticalOverlap = (p2.y + colOther_.size.y / 2.f) - (p.y - size.y / 2.f);
+        }
+
+        if (std::abs(horizontalOverlap) < std::abs(verticalOverlap)) {
+            if (p.x < p2.x) {
+                return CollisionSide::Right;
+            }
+            else {
+                return CollisionSide::Left;
+            }
+        }
+        else {
+            if (p.y < p2.y) {
+                return CollisionSide::Up;
+            }
+            else {
+                return CollisionSide::Down;
+            }
+        }
     }
-
-    else if (p.x > p2.x && ((p.x - p2.x) < (size.x + colOther_.size.x) / 2.f) &&
-        std::abs(p.y - p2.y) < (size.y + colOther_.size.y) / 2.f)
-    {
-        if (p.y + size.y / 2.f < p2.y) { return CollisionSide::Up; }
-        else if (p.y - size.y / 2.f > p2.y) { return CollisionSide::Down; }
-
-        return CollisionSide::Left;
+    else {
+        return CollisionSide::None;
     }
-
-    /*else if (p.y < p2.y && ((p2.y - p.y) < (size.y + colOther_.size.y) / 2.) &&
-        std::abs(p.x - p2.x) < (size.x + colOther_.size.x) / 2.)
-    {
-        return CollisionSide::Up;
-    }
-
-    else if (p.y > p2.y && ((p.y - p2.y) < (size.y + colOther_.size.y) / 2.) &&
-        std::abs(p.x - p2.x) < (size.x + colOther_.size.x) / 2.)
-    {
-        return CollisionSide::Down;
-    }*/
-
-    return CollisionSide::None;
 }
 
 //UNTESTED

--- a/source/dagger/gameplay/atonement/systems/character_collisions.cpp
+++ b/source/dagger/gameplay/atonement/systems/character_collisions.cpp
@@ -18,15 +18,15 @@ void CharacterCollisionsSystem::Run()
         auto& charTransform = view.get<Transform>(character);
 
         //resetujemo sve kolizije koje su postojale u proslom frejmu
-        charCollision.colidedLeft = false;
-        charCollision.colidedRight = false;
-        charCollision.colidedUp = false;
-        charCollision.colidedDown = false;
+        charCollision.collidedLeft = false;
+        charCollision.collidedRight = false;
+        charCollision.collidedUp = false;
+        charCollision.collidedDown = false;
 
-        charCollision.colidedWithLeft = entt::null;
-        charCollision.colidedWithRight = entt::null;
-        charCollision.colidedWithUp = entt::null;
-        charCollision.colidedWithDown = entt::null;
+        charCollision.collidedWithLeft = entt::null;
+        charCollision.collidedWithRight = entt::null;
+        charCollision.collidedWithUp = entt::null;
+        charCollision.collidedWithDown = entt::null;
 
         //svi ostali entiteti sa kolizijom
         auto simpleView = Engine::Registry().view<SimpleCollision, Transform>();
@@ -39,20 +39,20 @@ void CharacterCollisionsSystem::Run()
             
             switch (collisionDetection) {
                 case CollisionSide::Left: 
-                    charCollision.colidedLeft = true;
-                    charCollision.colidedWithLeft = entity;
+                    charCollision.collidedLeft = true;
+                    charCollision.collidedWithLeft = entity;
                     break;
                 case CollisionSide::Right:
-                    charCollision.colidedRight = true;
-                    charCollision.colidedWithRight = entity;
+                    charCollision.collidedRight = true;
+                    charCollision.collidedWithRight = entity;
                     break;
                 case CollisionSide::Up:
-                    charCollision.colidedUp = true;
-                    charCollision.colidedWithUp = entity;
+                    charCollision.collidedUp = true;
+                    charCollision.collidedWithUp = entity;
                     break;
                 case CollisionSide::Down:
-                    charCollision.colidedDown = true;
-                    charCollision.colidedWithDown = entity;
+                    charCollision.collidedDown = true;
+                    charCollision.collidedWithDown = entity;
                     break;
                 default: break;
             }

--- a/source/dagger/gameplay/atonement/systems/character_collisions.h
+++ b/source/dagger/gameplay/atonement/systems/character_collisions.h
@@ -22,14 +22,14 @@ namespace atonement {
         Vector2 size;
         Vector2 pivot{ -0.5f, -0.5f };
 
-        bool colidedLeft = false;
-        entt::entity colidedWithLeft = entt::null;
-        bool colidedRight = false;
-        entt::entity colidedWithRight = entt::null;
-        bool colidedUp = false;
-        entt::entity colidedWithUp = entt::null;
-        bool colidedDown = false;
-        entt::entity colidedWithDown = entt::null;
+        bool collidedLeft = false;
+        entt::entity collidedWithLeft = entt::null;
+        bool collidedRight = false;
+        entt::entity collidedWithRight = entt::null;
+        bool collidedUp = false;
+        entt::entity collidedWithUp = entt::null;
+        bool collidedDown = false;
+        entt::entity collidedWithDown = entt::null;
         
         CollisionSide IsCollided(const Vector3& pos_, const Vector3& posOther_, const SimpleCollision& colOther_);
 

--- a/source/dagger/gameplay/atonement/systems/collision_handler_system.cpp
+++ b/source/dagger/gameplay/atonement/systems/collision_handler_system.cpp
@@ -22,17 +22,17 @@ void CollisionHandlerSystem::Run()
 
             auto& col = view.get<CharacterCollision>(entity);
             
-            /*if (col.colidedLeft) {
-                std::cout << "Collided LEFT " << int(entity) << " " << int(col.colidedWithLeft) << std::endl;
+            /*if (col.collidedLeft) {
+                std::cout << "Collided LEFT " << int(entity) << " " << int(col.collidedWithLeft) << std::endl;
             }
-            if (col.colidedRight) {
-                std::cout << "Collided RIGHT " << int(entity) << " " << int(col.colidedWithRight) << std::endl;
+            if (col.collidedRight) {
+                std::cout << "Collided RIGHT " << int(entity) << " " << int(col.collidedWithRight) << std::endl;
             }
-            if (col.colidedUp) {
-                std::cout << "Collided UP " << int(entity) << " " << int(col.colidedWithUp) << std::endl;
+            if (col.collidedUp) {
+                std::cout << "Collided UP " << int(entity) << " " << int(col.collidedWithUp) << std::endl;
             }
-            if (col.colidedDown) {
-                std::cout << "Collided DOWN " << int(entity) << " " << int(col.colidedWithDown) << std::endl;
+            if (col.collidedDown) {
+                std::cout << "Collided DOWN " << int(entity) << " " << int(col.collidedWithDown) << std::endl;
             }*/
 
         }

--- a/source/dagger/gameplay/atonement/systems/groundedness_detection_system.cpp
+++ b/source/dagger/gameplay/atonement/systems/groundedness_detection_system.cpp
@@ -27,7 +27,7 @@ void GroundednessDetectionSystem::Run()
         {
                 bool tmp = char_.grounded;
 
-                if(collision_.colidedDown)
+                if(collision_.collidedDown)
                 {
                     char_.grounded = true;
                     char_.dashJumped = false;


### PR DESCRIPTION
Changed the collision system so that when colliding from two sides (left & up, left & down, right & up, right, & down) it detects it as the side it's the least deeply collided with.

For example, if we're falling from above, our player width is going to be wider than any intersection of colliders that may happen within a frame, which is going to be only a couple of pixels. Because vertical intersection is smaller than horizontal intersection, it will detect it as a vertical collision. Then we can easily use object midpoints to determine whether it's up or down.